### PR TITLE
Added key ("N") to manually trigger notification

### DIFF
--- a/notify-send.lua
+++ b/notify-send.lua
@@ -97,3 +97,4 @@ function notify_current_media()
 end
 
 mp.register_event("file-loaded", notify_current_media)
+mp.add_key_binding("N", notify_current_media)


### PR DESCRIPTION
This also makes it easy for people running mpv as an IPC-server to manually trigger the notification by calling

`echo '{ "command": ["keypress", "N"] }' | socat - /path/to/mpv-socket`

Resolves #5 